### PR TITLE
fix: improve YAML map format generation for mode groups

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/alecthomas/kong v1.9.0
 	github.com/charmbracelet/huh v0.6.0
 	github.com/charmbracelet/log v0.4.1
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (


### PR DESCRIPTION
- Use yaml.v3 package for proper YAML serialization
- Convert array format groups to map format for better readability
- Ensure consistent formatting of group options in markdown files