### PR TITLE
chore(github): update release workflow to specify owner and repository

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,8 @@ jobs:
         with:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}
+          owner: 'upamune'
+          repositories: 'homebrew-tap'
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@5fdedb94abba051217030cc86d4523cf3f02243d # v4.6.0
         with:


### PR DESCRIPTION
This commit enhances the GitHub Actions release workflow by adding the 'owner' and 'repositories' parameters for the GoReleaser step, ensuring proper configuration for the release process.